### PR TITLE
Saleszera/usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Global configuration is supported for the following options:
 ```ruby
 OmniAI::OpenAI.configure do |config|
   config.api_key = 'sk-...' # default: ENV['OPENAI_API_KEY']
+  config.admin_api_key = 'sk-admin...' # default: ENV['OPENAI_ADMIN_API_KEY']
   config.organization = '...' # default: ENV['OPENAI_ORGANIZATION']
   config.project = '...' # default: ENV['OPENAI_PROJECT']
   config.host = '...' # default: 'https://api.openai.com' - override for usage with LocalAI / Ollama
@@ -468,3 +469,26 @@ Text can be converted into a vector embedding for similarity comparison usage vi
 response = client.embed('The quick brown fox jumps over a lazy dog.')
 response.embedding # [0.0, ...]
 ```
+
+## OpenAI Usage
+### Costs
+
+Get costs details for the organization.
+
+```ruby
+start_time = 1739112382 # just start_time is required
+end_time = 1741704400
+group_by = ["project_id"]
+project_ids = ["proj_..."]
+limit = 30
+
+OmniAI::OpenAI::Usage::Cost.get(
+  start_time:, 
+  end_time:,
+  group_by:,
+  project_ids:, 
+  limit:
+) # { "object": "page", "has_more": false, "next_page": null, "data": [...] }
+```
+
+For more details, check it out [here](https://platform.openai.com/docs/api-reference/usage/costs)

--- a/lib/omniai/openai/config.rb
+++ b/lib/omniai/openai/config.rb
@@ -14,14 +14,20 @@ module OmniAI
       #   @return [String, nil] passed as `OpenAI-Organization` if specified
       attr_accessor :project
 
+      # @!attribute [rw] admin_api_key
+      #   @return [String, nil] passed as `OpenAI-Admin-Key` if specified
+      attr_accessor :admin_api_key
+
       # @param api_key [String, nil] optional - defaults to `ENV['OPENAI_API_KEY']`
       # @param host [String, nil] optional - defaults to ENV['OPENAI_HOST'] w/ fallback to `DEFAULT_HOST`
       # @param organization [String, nil] optional - defaults to `ENV['OPENAI_ORGANIZATION']`
       # @param project [String, nil] optional - defaults to `ENV['OPENAI_PROJECT']`
       # @param logger [Logger, nil] optional
       # @param timeout [Integer, Hash, nil] optional
+      # @param admin_api_key [String, nil] optional - defaults to `ENV['OPENAI_ADMIN_API_KEY']`
       def initialize(
         api_key: ENV.fetch("OPENAI_API_KEY", nil),
+        admin_api_key: ENV.fetch("OPENAI_ADMIN_API_KEY", nil),
         host: ENV.fetch("OPENAI_HOST", DEFAULT_HOST),
         organization: ENV.fetch("OPENAI_ORGANIZATION", nil),
         project: ENV.fetch("OPENAI_PROJECT", nil),
@@ -30,6 +36,7 @@ module OmniAI
       )
         super(api_key:, host:, logger:, timeout:)
 
+        @admin_api_key = admin_api_key
         @organization = organization
         @project = project
       end

--- a/lib/omniai/openai/usage/cost.rb
+++ b/lib/omniai/openai/usage/cost.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module OpenAI
+    module Usage
+      # An OpenAI cost implementation.
+      class Cost
+        # @!attribute [r] start_time
+        #   @return [Time]
+        attr_reader :start_time
+
+        # @!attribute [r] end_time
+        #   @return [Time, nil]
+        attr_reader :end_time
+
+        # @!attribute [r] bucket_width
+        #   @return [String, nil]
+        attr_reader :bucket_width
+
+        # @!attribute [r] project_ids
+        #   @return [Array<String>, nil]
+        attr_reader :project_ids
+
+        # @!attribute [r] group_by
+        #   @return [Array<String>, nil]
+        attr_reader :group_by
+
+        # @!attribute [r] limit
+        #   @return [Integer, nil]
+        attr_reader :limit
+
+        # @!attribute [r] page
+        #   @return [Integer, nil]
+        attr_reader :page
+
+        # @param start_time [Time]
+        # @param end_time [Time, nil] optional
+        # @param bucket_width [String, nil] optional
+        # @param project_ids [Array<String>, nil] optional
+        # @param group_by [Array<String>, nil] optional
+        # @param limit [Integer, nil] optional
+        # @param page [Integer, nil] optional
+        def initialize(
+          start_time:,
+          end_time: nil,
+          bucket_width: nil,
+          project_ids: nil,
+          group_by: nil,
+          limit: nil,
+          page: nil
+        )
+          @start_time = start_time
+          @end_time = end_time
+          @bucket_width = bucket_width
+          @project_ids = project_ids
+          @group_by = group_by
+          @limit = limit
+          @page = page
+          @client = OmniAI::OpenAI::Client.new(api_key: OmniAI::OpenAI.config.admin_api_key)
+
+          validate_array_params!
+        end
+
+        # @param response [HTTP::Response]
+        def self.get(**args)
+          new(**args).get
+        end
+
+        # @param response [HTTP::Response]
+        def get
+          response = @client.connection
+            .accept(:json)
+            .get("/#{OmniAI::OpenAI::Client::VERSION}/organization/costs?#{request_params}")
+
+          raise HTTPError, response.flush unless response.status.ok?
+
+          response.parse
+        end
+
+      private
+
+        # @return [String]
+        def request_params
+          params = {
+            start_time:,
+            end_time:,
+            bucket_width:,
+            project_ids: project_ids&.join(","),
+            group_by: group_by&.join(","),
+            limit:,
+            page:,
+          }.compact
+
+          URI.encode_www_form(params)
+        end
+
+        # @raise [ArgumentError]
+        # @return [void]
+        def validate_array_params!
+          raise ArgumentError, "project_ids must be an Array" if project_ids && !project_ids.is_a?(Array)
+
+          return unless group_by && !group_by.is_a?(Array)
+
+          raise ArgumentError, "group_by must be an Array"
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/openai/version.rb
+++ b/lib/omniai/openai/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module OpenAI
-    VERSION = "1.9.3"
+    VERSION = "1.9.4"
   end
 end

--- a/spec/omniai/openai/usage/cost_spec.rb
+++ b/spec/omniai/openai/usage/cost_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::OpenAI::Usage::Cost do
+  before do
+    OmniAI::OpenAI.configure do |config|
+      config.admin_api_key = "fake_admin_key"
+    end
+  end
+
+  let(:params) do
+    {
+      start_time: 1_739_112_382,
+      end_time: 1_741_704_400,
+      bucket_width: nil,
+      project_ids: ["proj_6fLLCZmchmiqHfzSKWYVMUtr"],
+      group_by: ["project_id"],
+      limit: 100,
+      page: nil,
+    }
+  end
+
+  describe ".get" do
+    subject(:cost_response) { described_class.get(**params) }
+
+    context "with an OK response" do
+      let(:response_body) do
+        {
+          "total_cost" => 123.45,
+          "currency" => "USD",
+          "breakdown" => [
+            { "project_id" => "proj_6fLLCZmchmiqHfzSKWYVMUtr", "cost" => 123.45 },
+          ],
+        }
+      end
+
+      before do
+        stub_request(:get, %r{https://api\.openai\.com/v1/organization/costs\?})
+          .with(query: hash_including(
+            "start_time" => params[:start_time].to_s,
+            "end_time" => params[:end_time].to_s,
+            "project_ids" => params[:project_ids].join(","),
+            "group_by" => params[:group_by].join(","),
+            "limit" => params[:limit].to_s
+          ))
+          .to_return(
+            body: response_body.to_json,
+            status: 200,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "returns the parsed response" do
+        expect(cost_response).to eq(response_body)
+      end
+    end
+
+    context "with an error response" do
+      before do
+        stub_request(:get, %r{https://api\.openai\.com/v1/organization/costs\?})
+          .to_return(
+            body: { "error" => "Not Found" }.to_json,
+            status: 404,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "raises an HTTPError" do
+        expect { cost_response }.to raise_error(OmniAI::HTTPError)
+      end
+    end
+
+    context "with invalid parameters" do
+      subject(:cost_response) { described_class.get(**invalid_params) }
+
+      let(:invalid_params) do
+        # Passing strings instead of arrays for project_ids and group_by.
+        params.merge(
+          project_ids: "not-an-array",
+          group_by: "not-an-array"
+        )
+      end
+
+      it "raises a NoMethodError" do
+        expect { cost_response }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# CHANGELOG 📝 
> This pull request introduces support for an admin API key and adds a new feature for retrieving cost details from the OpenAI API. The most important changes include updates to the configuration, the addition of a new cost usage module, and corresponding documentation and tests.

### Configuration Updates:
* [`lib/omniai/openai/config.rb`](diffhunk://#diff-78051c35cd575e8deaebce397844e1db22b8318c15ee44dd91d8571f3607d5c3R17-R30): Added `admin_api_key` attribute to the configuration class, allowing it to be set and used for API requests. [[1]](diffhunk://#diff-78051c35cd575e8deaebce397844e1db22b8318c15ee44dd91d8571f3607d5c3R17-R30) [[2]](diffhunk://#diff-78051c35cd575e8deaebce397844e1db22b8318c15ee44dd91d8571f3607d5c3R39)

### New Feature - Cost Usage:
* [`lib/omniai/openai/usage/cost.rb`](diffhunk://#diff-c53a54a447bc71d753edde0ddc21df273576ab654d213462ca41e3f01adc8525R1-R109): Introduced a new `Cost` class to handle requests for cost details from the OpenAI API. This includes methods for initializing parameters, validating input, and making HTTP requests to retrieve cost data.
* [`spec/omniai/openai/usage/cost_spec.rb`](diffhunk://#diff-59e289bb7957f80c848d9ae4861d0a657299f44a6f9f3a54645d2676973f3871R1-R88): Added tests for the new `Cost` class, covering scenarios for successful responses, error responses, and invalid parameters.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42): Updated to include the new `admin_api_key` configuration option and added a section detailing how to use the new cost retrieval feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R472-R494)

### Version Bump:
* [`lib/omniai/openai/version.rb`](diffhunk://#diff-a16967330cabed411715dabf0e7038c3371740f7ee9609d9260a186c107dd47bL5-R5): Incremented the version number from `1.9.3` to `1.9.4` to reflect the new changes.

![that's it folks](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExaGlnMWJmYWxjNTRqYjNzOGVpZGdzcWRjeTRyY3duYjczeDh2M3pvYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lD76yTC5zxZPG/giphy.gif)