### PR TITLE
Speak / Transcribe Model Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-openai (2.0.1)
+    omniai-openai (2.0.2)
       event_stream_parser
       omniai (~> 2.0)
       zeitwerk

--- a/lib/omniai/openai/client.rb
+++ b/lib/omniai/openai/client.rb
@@ -125,7 +125,7 @@ module OmniAI
       # @yield [output] optional
       #
       # @return [Tempfile``]
-      def speak(input, model: Speak::Model::TTS_1_HD, voice: Speak::Voice::ALLOY, speed: nil, format: nil, &)
+      def speak(input, model: Speak::DEFAULT_MODEL, voice: Speak::DEFAULT_VOICE, speed: nil, format: nil, &)
         Speak.process!(input, model:, voice:, speed:, format:, client: self, &)
       end
 

--- a/lib/omniai/openai/client.rb
+++ b/lib/omniai/openai/client.rb
@@ -104,7 +104,7 @@ module OmniAI
       # @param format [Symbol] :text, :srt, :vtt, or :json (default)
       #
       # @return [OmniAI::Transcribe]
-      def transcribe(path, model: Transcribe::Model::WHISPER, language: nil, prompt: nil, temperature: nil, format: nil)
+      def transcribe(path, model: Transcribe::DEFAULT_MODEL, language: nil, prompt: nil, temperature: nil, format: nil)
         Transcribe.process!(path, model:, language:, prompt:, temperature:, format:, client: self)
       end
 

--- a/lib/omniai/openai/speak.rb
+++ b/lib/omniai/openai/speak.rb
@@ -7,16 +7,24 @@ module OmniAI
       module Model
         TTS_1 = "tts-1"
         TTS_1_HD = "tts-1-hd"
+        GPT_4O_MINI_TTS = "gpt-4o-mini-tts"
       end
 
       module Voice
         ALLOY = "alloy" # https://platform.openai.com/docs/guides/text-to-speech/alloy
+        ASH = "ash" # https://platform.openai.com/docs/guides/text-to-speech/ash
+        BALLARD = "ballard" # https://platform.openai.com/docs/guides/text-to-speech/ballard
+        CORAL = "coral" # https://platform.openai.com/docs/guides/text-to-speech/coral
         ECHO = "echo" # https://platform.openai.com/docs/guides/text-to-speech/echo
         FABLE = "fable" # https://platform.openai.com/docs/guides/text-to-speech/fable
         NOVA = "nova" # https://platform.openai.com/docs/guides/text-to-speech/nova
         ONYX = "onyx" # https://platform.openai.com/docs/guides/text-to-speech/onyx
+        SAGE = "sage" # https://platform.openai.com/docs/guides/text-to-speech/sage
         SHIMMER = "shimmer" # https://platform.openai.com/docs/guides/text-to-speech/shimmer
       end
+
+      DEFAULT_MODEL = Model::GPT_4O_MINI_TTS
+      DEFAULT_VOICE = Voice::ALLOY
 
     protected
 

--- a/lib/omniai/openai/transcribe.rb
+++ b/lib/omniai/openai/transcribe.rb
@@ -6,8 +6,12 @@ module OmniAI
     class Transcribe < OmniAI::Transcribe
       module Model
         WHISPER_1 = "whisper-1"
+        GPT_4O_TRANSCRIBE = "gpt-4o-transcribe"
+        GPT_4O_MINI_TRANSCRIBE = "gpt-4-0-mini-transcribe"
         WHISPER = WHISPER_1
       end
+
+      DEFAULT_MODEL = Model::WHISPER
 
     protected
 

--- a/lib/omniai/openai/version.rb
+++ b/lib/omniai/openai/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module OpenAI
-    VERSION = "2.0.1"
+    VERSION = "2.0.2"
   end
 end


### PR DESCRIPTION
This supports the latest models / voices for the `#speak` API and the latest models for the `#transcribe` API. It also swaps the default model for `#speak` to `gpt-4o-mini-tts`.