### PR TITLE
Track Usage when Streaming

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-openai (2.0.2)
+    omniai-openai (2.2.0)
       event_stream_parser
-      omniai (~> 2.0)
+      omniai (~> 2.2)
       zeitwerk
 
 GEM
@@ -52,7 +52,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.6.6)
-    omniai (2.1.1)
+    omniai (2.2.0)
       event_stream_parser
       http
       logger

--- a/lib/omniai/openai/chat.rb
+++ b/lib/omniai/openai/chat.rb
@@ -13,6 +13,7 @@ module OmniAI
     #   completion.choice.message.content # '...'
     class Chat < OmniAI::Chat
       JSON_RESPONSE_FORMAT = { type: "json_object" }.freeze
+      DEFAULT_STREAM_OPTIONS = { include_usage: ENV.fetch("OMNIAI_STREAM_USAGE", "on").eql?("on") }.freeze
 
       module Model
         GPT_4O = "gpt-4o"
@@ -35,9 +36,10 @@ module OmniAI
         OmniAI::OpenAI.config.chat_options.merge({
           messages: @prompt.serialize,
           model: @model,
-          stream: @stream.nil? ? nil : !@stream.nil?,
-          temperature: @temperature,
           response_format: (JSON_RESPONSE_FORMAT if @format.eql?(:json)),
+          stream: stream? || nil,
+          stream_options: (DEFAULT_STREAM_OPTIONS if stream?),
+          temperature: @temperature,
           tools: (@tools.map(&:serialize) if @tools&.any?),
         }).compact
       end

--- a/lib/omniai/openai/version.rb
+++ b/lib/omniai/openai/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module OpenAI
-    VERSION = "2.0.2"
+    VERSION = "2.2.0"
   end
 end

--- a/omniai-openai.gemspec
+++ b/omniai-openai.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 2.0"
+  spec.add_dependency "omniai", "~> 2.2"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/openai/chat_spec.rb
+++ b/spec/omniai/openai/chat_spec.rb
@@ -137,7 +137,8 @@ RSpec.describe OmniAI::OpenAI::Chat do
               { role: "user", content: [{ type: "text", text: "Tell me a story." }] },
             ],
             model:,
-            stream: !stream.nil?,
+            stream: true,
+            stream_options: { include_usage: true },
           })
           .to_return(body: <<~STREAM)
             data: #{JSON.generate({ choices: [{ index: 0, delta: { role: 'assistant', content: 'Hello' } }] })}\n


### PR DESCRIPTION
This ensure when streaming usage is returned. Prior to this the `response.usage` returned `nil`, making it impossible to track usage when using the streaming APIs.