### PR TITLE
Support for GPT-4.1 (default + mini + nano)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-openai (2.2.1)
+    omniai-openai (2.2.2)
       event_stream_parser
       omniai (~> 2.2)
       zeitwerk

--- a/lib/omniai/openai/chat.rb
+++ b/lib/omniai/openai/chat.rb
@@ -16,6 +16,9 @@ module OmniAI
       DEFAULT_STREAM_OPTIONS = { include_usage: ENV.fetch("OMNIAI_STREAM_USAGE", "on").eql?("on") }.freeze
 
       module Model
+        GPT_4_1 = "gpt-4.1"
+        GPT_4_1_NANO = "gpt-4.1-nano"
+        GPT_4_1_MINI = "gpt-4.1-mini"
         GPT_4O = "gpt-4o"
         GPT_4O_MINI = "gpt-4o-mini"
         GPT_4 = "gpt-4"
@@ -26,7 +29,7 @@ module OmniAI
         O1 = "o1"
       end
 
-      DEFAULT_MODEL = Model::GPT_4O
+      DEFAULT_MODEL = Model::GPT_4_1
 
     protected
 

--- a/lib/omniai/openai/version.rb
+++ b/lib/omniai/openai/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module OpenAI
-    VERSION = "2.2.1"
+    VERSION = "2.2.2"
   end
 end


### PR DESCRIPTION
Note: this swaps the default model to 4.1 from 4o.