### PR TITLE
Fix dropped Responses API options, stale models, and two wrong model/voice names

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,15 @@ completion.content # 'The capital of Canada is Ottawa.'
 
 #### Model
 
-`model` takes an optional string (default is `gpt-4o`):
+`model` takes an optional string (default is `gpt-5.2`):
 
 ```ruby
-completion = client.chat('How fast is a cheetah?', model: OmniAI::OpenAI::Chat::Model::GPT_3_5_TURBO)
+completion = client.chat('How fast is a cheetah?', model: OmniAI::OpenAI::Chat::Model::GPT_5_5)
 completion.content # 'A cheetah can reach speeds over 100 km/h.'
 ```
+
+Note that `temperature` is not supported by every model (e.g. `gpt-5`, `gpt-5.5` and the `o`-series). It is
+omitted from the request for those models rather than sent and rejected — see `TEMPERATURE_UNSUPPORTED_MODELS`.
 
 [OpenAI API Reference `model`](https://platform.openai.com/docs/api-reference/chat/create#chat-create-model)
 
@@ -195,6 +198,23 @@ client.chat("What are the prime factors of 1234567?", model: "o3-mini", thinking
 ```
 
 [OpenAI API Reference `reasoning`](https://platform.openai.com/docs/guides/reasoning)
+
+#### Other Responses API Options
+
+Any option that is not modelled explicitly is forwarded to the Responses API verbatim, so parameters the gem
+does not wrap are still reachable:
+
+```ruby
+completion = client.chat('Summarize this.', model: 'gpt-5.5', max_output_tokens: 512, store: false)
+
+# continue a stored conversation
+completion = client.chat('And the next one?', previous_response_id: 'resp_123')
+```
+
+This covers `max_output_tokens`, `previous_response_id`, `store`, `parallel_tool_calls`, `metadata`,
+`truncation`, `top_p`, `service_tier`, and `prompt_cache_key`, among others.
+
+[OpenAI API Reference `responses`](https://platform.openai.com/docs/api-reference/responses/create)
 
 ### Transcribe
 
@@ -281,7 +301,7 @@ client.speak('She sells seashells by the seashore.', voice: OmniAI::OpenAI::Spea
 
 #### Model
 
-`model` is optional and must be either `tts-1` or `tts-1-hd` (default):
+`model` is optional and is one of `tts-1`, `tts-1-hd`, or `gpt-4o-mini-tts` (default):
 
 ```ruby
 client.speak('I saw a kitten eating chicken in the kitchen.', format: OmniAI::OpenAI::Speak::Model::TTS_1)

--- a/lib/omniai/openai/chat.rb
+++ b/lib/omniai/openai/chat.rb
@@ -32,11 +32,23 @@ module OmniAI
       end
 
       module Model
+        GPT_5_6_LUNA = "gpt-5.6-luna"
+        GPT_5_6_SOL = "gpt-5.6-sol"
+        GPT_5_6_TERRA = "gpt-5.6-terra"
+        GPT_5_5 = "gpt-5.5"
+        GPT_5_5_PRO = "gpt-5.5-pro"
+        GPT_5_4 = "gpt-5.4"
+        GPT_5_4_MINI = "gpt-5.4-mini"
+        GPT_5_4_NANO = "gpt-5.4-nano"
+        GPT_5_4_PRO = "gpt-5.4-pro"
+        GPT_5_3_CODEX = "gpt-5.3-codex"
         GPT_5_2 = "gpt-5.2"
+        GPT_5_2_PRO = "gpt-5.2-pro"
         GPT_5_1 = "gpt-5.1"
         GPT_5 = "gpt-5"
         GPT_5_MINI = "gpt-5-mini"
         GPT_5_NANO = "gpt-5-nano"
+        GPT_5_PRO = "gpt-5-pro"
         GPT_4_1 = "gpt-4.1"
         GPT_4_1_NANO = "gpt-4.1-nano"
         GPT_4_1_MINI = "gpt-4.1-mini"
@@ -53,6 +65,38 @@ module OmniAI
       end
 
       DEFAULT_MODEL = Model::GPT_5_2
+
+      # Models that reject `temperature` on the Responses API.
+      #
+      # OpenAI's support here is not patterned by version, so this cannot be a prefix rule: `gpt-5` and its
+      # mini/nano/pro variants reject `temperature`, `gpt-5.1` through `gpt-5.4` accept it, and `gpt-5.5`
+      # onwards rejects it again. Every entry below was verified live against the API on 2026-08-16 by issuing
+      # a request with `temperature` and checking for `Unsupported parameter`.
+      #
+      # Models absent from this list pass `temperature` through unchanged. That is deliberate: an unlisted
+      # model that rejects it surfaces a loud API error the caller can act on, whereas over-applying the guard
+      # would silently discard a caller's temperature.
+      TEMPERATURE_UNSUPPORTED_MODELS = [
+        Model::GPT_5_6_LUNA,
+        Model::GPT_5_6_SOL,
+        Model::GPT_5_6_TERRA,
+        Model::GPT_5_5,
+        Model::GPT_5_5_PRO,
+        Model::GPT_5_4_PRO,
+        Model::GPT_5_2_PRO,
+        Model::GPT_5,
+        Model::GPT_5_MINI,
+        Model::GPT_5_NANO,
+        Model::GPT_5_PRO,
+        Model::O1_MINI,
+        Model::O1,
+        Model::O3,
+        Model::O3_MINI,
+        Model::O4_MINI,
+      ].freeze
+
+      # Keys in `@options` consumed by dedicated builders below rather than sent verbatim.
+      RESERVED_OPTIONS = %i[text reasoning thinking].freeze
 
       # @return [Context]
       CONTEXT = Context.build do |context|
@@ -106,36 +150,38 @@ module OmniAI
         parts.join("\n\n")
       end
 
+      # @return [String]
+      def model
+        @model || DEFAULT_MODEL
+      end
+
       # @return [Float, nil]
       def temperature
         return if @temperature.nil?
-
-        return if [
-          Model::GPT_5,
-          Model::GPT_5_MINI,
-          Model::GPT_5_NANO,
-          Model::GPT_5_1,
-          Model::GPT_5_2,
-          Model::O1_MINI,
-          Model::O1,
-          Model::O3_MINI,
-        ].include?(@model)
+        return if TEMPERATURE_UNSUPPORTED_MODELS.include?(model)
 
         @temperature
       end
 
+      # Unrecognized options are passed through verbatim so callers can reach Responses API parameters the gem
+      # does not model explicitly (e.g. `max_output_tokens`, `previous_response_id`, `store`,
+      # `parallel_tool_calls`, `metadata`, `truncation`, `top_p`). Keys built by dedicated methods are excluded
+      # so they are not sent twice, and the explicit keys below win over any same-named passthrough.
+      #
       # @return [Hash]
       def payload
-        OmniAI::OpenAI.config.chat_options.merge({
-          instructions:,
-          input:,
-          model: @model || DEFAULT_MODEL,
-          stream: stream? || nil,
-          temperature:,
-          tools:,
-          text:,
-          reasoning:,
-        }).compact
+        OmniAI::OpenAI.config.chat_options
+          .merge(@options.except(*RESERVED_OPTIONS))
+          .merge({
+            instructions:,
+            input:,
+            model:,
+            stream: stream? || nil,
+            temperature:,
+            tools:,
+            text:,
+            reasoning:,
+          }).compact
       end
 
       # @return [Array<Hash>]

--- a/lib/omniai/openai/speak.rb
+++ b/lib/omniai/openai/speak.rb
@@ -13,14 +13,17 @@ module OmniAI
       module Voice
         ALLOY = "alloy" # https://platform.openai.com/docs/guides/text-to-speech/alloy
         ASH = "ash" # https://platform.openai.com/docs/guides/text-to-speech/ash
-        BALLARD = "ballard" # https://platform.openai.com/docs/guides/text-to-speech/ballard
+        BALLAD = "ballad" # https://platform.openai.com/docs/guides/text-to-speech/ballad
+        CEDAR = "cedar" # https://platform.openai.com/docs/guides/text-to-speech/cedar
         CORAL = "coral" # https://platform.openai.com/docs/guides/text-to-speech/coral
         ECHO = "echo" # https://platform.openai.com/docs/guides/text-to-speech/echo
         FABLE = "fable" # https://platform.openai.com/docs/guides/text-to-speech/fable
+        MARIN = "marin" # https://platform.openai.com/docs/guides/text-to-speech/marin
         NOVA = "nova" # https://platform.openai.com/docs/guides/text-to-speech/nova
         ONYX = "onyx" # https://platform.openai.com/docs/guides/text-to-speech/onyx
         SAGE = "sage" # https://platform.openai.com/docs/guides/text-to-speech/sage
         SHIMMER = "shimmer" # https://platform.openai.com/docs/guides/text-to-speech/shimmer
+        VERSE = "verse" # https://platform.openai.com/docs/guides/text-to-speech/verse
       end
 
       DEFAULT_MODEL = Model::GPT_4O_MINI_TTS

--- a/lib/omniai/openai/transcribe.rb
+++ b/lib/omniai/openai/transcribe.rb
@@ -7,7 +7,10 @@ module OmniAI
       module Model
         WHISPER_1 = "whisper-1"
         GPT_4O_TRANSCRIBE = "gpt-4o-transcribe"
-        GPT_4O_MINI_TRANSCRIBE = "gpt-4-0-mini-transcribe"
+        GPT_4O_TRANSCRIBE_DIARIZE = "gpt-4o-transcribe-diarize"
+        GPT_4O_MINI_TRANSCRIBE = "gpt-4o-mini-transcribe"
+        GPT_TRANSCRIBE = "gpt-transcribe"
+        GPT_LIVE_TRANSCRIBE = "gpt-live-transcribe"
         WHISPER = WHISPER_1
       end
 

--- a/spec/omniai/openai/chat_spec.rb
+++ b/spec/omniai/openai/chat_spec.rb
@@ -91,6 +91,100 @@ RSpec.describe OmniAI::OpenAI::Chat do
       it { expect(completion.text).to eql("3") }
     end
 
+    # Verified live 2026-08-16: gpt-5.1 accepts `temperature` on the Responses API. It was previously listed as
+    # unsupported, so a caller's temperature was silently dropped rather than sent.
+    context "with a temperature using a gpt-5.x model that supports" do
+      subject(:completion) { described_class.process!(prompt, client:, model:, temperature:) }
+
+      let(:model) { described_class::Model::GPT_5_1 }
+      let(:prompt) { "Pick a number between 1 and 5." }
+      let(:temperature) { 2.0 }
+
+      before do
+        stub_request(:post, "https://api.openai.com/v1/responses")
+          .with(body: {
+            input: [{
+              role: "user",
+              content: [{ type: "input_text", text: "Pick a number between 1 and 5." }],
+            }],
+            model:,
+            temperature:,
+          })
+          .to_return_json(body: {
+            output: [{
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "3" }],
+            }],
+          })
+      end
+
+      it { expect(completion.text).to eql("3") }
+    end
+
+    # Verified live 2026-08-16: gpt-5.5 rejects `temperature` with `Unsupported parameter`.
+    context "with a temperature using a newer model that does not support" do
+      subject(:completion) { described_class.process!(prompt, client:, model:, temperature:) }
+
+      let(:model) { described_class::Model::GPT_5_5 }
+      let(:prompt) { "Pick a number between 1 and 5." }
+      let(:temperature) { 2.0 }
+
+      before do
+        stub_request(:post, "https://api.openai.com/v1/responses")
+          .with(body: {
+            input: [{
+              role: "user",
+              content: [{ type: "input_text", text: "Pick a number between 1 and 5." }],
+            }],
+            model:,
+          })
+          .to_return_json(body: {
+            output: [{
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "3" }],
+            }],
+          })
+      end
+
+      it { expect(completion.text).to eql("3") }
+    end
+
+    context "with Responses API options the gem does not model explicitly" do
+      subject(:completion) do
+        described_class.process!(prompt, client:, model:, max_output_tokens: 24, store: false,
+          previous_response_id: "resp_123", parallel_tool_calls: false, metadata: { "key" => "value" })
+      end
+
+      let(:prompt) { "Tell me a joke!" }
+
+      before do
+        stub_request(:post, "https://api.openai.com/v1/responses")
+          .with(body: {
+            input: [{
+              role: "user",
+              content: [{ type: "input_text", text: "Tell me a joke!" }],
+            }],
+            model:,
+            max_output_tokens: 24,
+            store: false,
+            previous_response_id: "resp_123",
+            parallel_tool_calls: false,
+            metadata: { "key" => "value" },
+          })
+          .to_return_json(body: {
+            output: [{
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "Two elephants fall off a cliff. Boom! Boom!" }],
+            }],
+          })
+      end
+
+      it { expect(completion.text).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+    end
+
     context "with a temperature using a model that does not support" do
       subject(:completion) { described_class.process!(prompt, client:, model:, temperature:) }
 


### PR DESCRIPTION
Audited `omniai-openai` against the **live** OpenAI API. Four defects, all invisible to the existing suite — it is WebMock-only, so it can only confirm the gem is self-consistent, never that it matches the API. All 65 examples passed green through every bug below.

Each fix was verified live before and after the change.

## 1. Request options were silently dropped

`Chat#payload` built a closed hash of eight keys. Anything else passed via `**options` vanished — no error, no warning:

```ruby
Chat.new("hi", model: "gpt-5.5", max_output_tokens: 24, store: false, previous_response_id: "resp_x", ...)
# payload keys before: [:input, :model]      ← all nine dropped
```

Confirmed live: `max_output_tokens: 24` was ignored and the model ran to completion. The same request via curl truncated correctly. This also made `previous_response_id` + `store` — the Responses API's stateful-conversation feature — unreachable through the gem.

Options are now forwarded verbatim, minus the keys built by dedicated methods (`text`, `reasoning`, `thinking`). After:

```
max_output_tokens honored?  status=incomplete incomplete={"reason" => "max_output_tokens"} out_tokens=24
```

## 2. The `temperature` guard was wrong in both directions

Support is **not** patterned by version, so this cannot be a prefix rule. Live matrix:

| Rejects `temperature` | Accepts `temperature` |
|---|---|
| `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro` | `gpt-5.1`, `gpt-5.2`, `gpt-5.3-codex` |
| `gpt-5.2-pro`, `gpt-5.4-pro`, `gpt-5.5-pro` | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` |
| `gpt-5.5`, `gpt-5.6-luna/sol/terra` | `gpt-4`, `gpt-4.1`, `gpt-4o`, `gpt-3.5-turbo` |
| `o1`, `o3`, `o3-mini`, `o4-mini` | |

The old list wrongly included `gpt-5.1`/`gpt-5.2` — **silently discarding a caller's temperature** — and missed `gpt-5.5`, `gpt-5.6-*`, the `-pro` variants, `o3` and `o4-mini`, each of which **400s**.

Note the deliberate asymmetry, documented in the code: models *absent* from the list now pass `temperature` through. A missing entry surfaces a loud API error the caller can act on; an extra entry fails silently. Under-applying is the safer direction, which is why there is no heuristic.

## 3. Model constants three generations stale

Newest constant was `gpt-5.2`; the live API has 5.3/5.4/5.5/5.6 families plus `-pro` variants. Added.

**`DEFAULT_MODEL` is intentionally unchanged** at `gpt-5.2` — bumping it changes behaviour and cost for every existing caller, which is your call rather than a bugfix.

## 4. Two constants did not name a real resource

| Constant | Was | Live | Now |
|---|---|---|---|
| `Transcribe::Model::GPT_4O_MINI_TRANSCRIBE` | `gpt-4-0-mini-transcribe` | **404** | `gpt-4o-mini-transcribe` (200) |
| `Speak::Voice::BALLARD` | `ballard` | **400** | `ballad` (200) |

Also added the missing `verse`, `marin`, `cedar` voices and the newer transcribe models — all verified 200.

⚠️ `Voice::BALLARD` is **removed**, not aliased. It is a public constant, but it could never have worked (every call 400s), so no working code can depend on it.

## Verification

```
68 examples, 0 failures          # 3 new
45 files inspected, no offenses detected
```

Plus live re-verification of all four fixes after the change.

## Deliberately not included

- **`finish_reason` is still unwired.** Base omniai 3.7.0 added `FinishReason` to `Response`/`Choice` — Anthropic and Google both implement it, OpenAI has zero references. It matters here: a truncated call returns `status: "incomplete"` with a reasoning-only output array and **no text at all**, giving callers an empty response and no way to know why. Left out because it requires bumping the `omniai` dependency past 3.7.0 (the gem currently resolves 3.6.0, where `response.finish_reason` raises `NoMethodError`), which is a release-sequencing decision.
- **`choices` conflates reasoning items with messages.** `ResponseSerializer` maps each `output` entry to a `Choice`, so a reasoning + message response yields `choices.size == 2`. The Responses API returns one logical choice. Fixing it changes observable arity, so it wants a deliberate breaking-change decision.