### PR TITLE
Read reasoning tokens from the Responses API usage object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 3.2.0
+
+### Added
+
+- `OmniAI::Chat::Usage#thinking_tokens` is now populated from the Responses API `usage` object, read from `output_tokens_details.reasoning_tokens`. Reasoning spend was previously unreadable through this gem — callers had to reach into `response.data`. Requires omniai >= 3.8.
+
+  OpenAI already counts reasoning inside `output_tokens`, so this reports the breakdown without changing the output total. `thinking_tokens` is a subset, not an addition — adding it to `output_tokens` double counts.
+
+  Note the vocabulary: this gem targets the Responses API (`/responses`), whose usage object nests the breakdown under `output_tokens_details`. The `completion_tokens_details` key belongs to Chat Completions, the previous API generation, and is deliberately not read — this gem never receives it.
+
+- Specs for usage deserialization, which this suite previously had none of.
+
+Earlier changes are recorded in the GitHub releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   Note the vocabulary: this gem targets the Responses API (`/responses`), whose usage object nests the breakdown under `output_tokens_details`. The `completion_tokens_details` key belongs to Chat Completions, the previous API generation, and is deliberately not read — this gem never receives it.
 
-- Specs for usage deserialization, which this suite previously had none of.
+- Specs for usage deserialization, which this suite previously had none of. Fixtures are captured from a live `/v1/responses` call and carry provenance comments naming model, endpoint and date.
+
+### Changed
+
+- The `omniai` dependency floor moves from `~> 3.0` to `~> 3.8`. If you are on omniai 3.0–3.7 this is a forced upgrade, and it is the largest one in this release train: `Usage#thinking_tokens` does not exist before 3.8, so without the bump this gem would install cleanly and the new field would silently read `nil` rather than the reasoning count. The old floor was also simply stale — it predates several releases this gem already depended on in practice.
 
 Earlier changes are recorded in the GitHub releases.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-openai (3.1.2)
+    omniai-openai (3.2.0)
       event_stream_parser
-      omniai (~> 3.0)
+      omniai (~> 3.8)
       openssl
       zeitwerk
 
@@ -51,10 +51,10 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    omniai (3.6.0)
+    omniai (3.8.0)
       base64
       event_stream_parser
-      http (~> 5)
+      http (>= 5, < 7)
       logger
       zeitwerk
     openssl (4.0.2)

--- a/lib/omniai/openai/chat.rb
+++ b/lib/omniai/openai/chat.rb
@@ -109,6 +109,7 @@ module OmniAI
         context.serializers[:response] = ResponseSerializer.method(:serialize)
         context.deserializers[:response] = ResponseSerializer.method(:deserialize)
         context.deserializers[:content] = ContentSerializer.method(:deserialize)
+        context.deserializers[:usage] = UsageSerializer.method(:deserialize)
         context.serializers[:file] = FileSerializer.method(:serialize)
         context.serializers[:url] = URLSerializer.method(:serialize)
         context.serializers[:tool] = ToolSerializer.method(:serialize)

--- a/lib/omniai/openai/chat/usage_serializer.rb
+++ b/lib/omniai/openai/chat/usage_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module OpenAI
+    class Chat
+      # Overrides usage deserialize to read OpenAI's reasoning breakdown.
+      module UsageSerializer
+        # OpenAI already counts reasoning inside `output_tokens` and reports the breakdown alongside it, so the
+        # breakdown is read into `thinking_tokens` and the output count is left exactly as reported. Adding the two
+        # together would double count.
+        #
+        # This gem targets the Responses API (`/responses`), whose usage object reports the breakdown at
+        # `output_tokens_details.reasoning_tokens`. The Chat Completions vocabulary from the previous API
+        # generation (`completion_tokens_details`) is deliberately not read — this gem never receives it.
+        #
+        # @param data [Hash]
+        # @return [OmniAI::Chat::Usage]
+        def self.deserialize(data, *)
+          # Deserialize without a context so the generic flat parse runs rather than recursing into this method.
+          usage = OmniAI::Chat::Usage.deserialize(data)
+          usage.thinking_tokens = data.dig("output_tokens_details", "reasoning_tokens")
+          usage
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/openai/chat/usage_serializer.rb
+++ b/lib/omniai/openai/chat/usage_serializer.rb
@@ -18,7 +18,14 @@ module OmniAI
         def self.deserialize(data, *)
           # Deserialize without a context so the generic flat parse runs rather than recursing into this method.
           usage = OmniAI::Chat::Usage.deserialize(data)
-          usage.thinking_tokens = data.dig("output_tokens_details", "reasoning_tokens")
+
+          # Only overwrite when the vendor container is actually present. A payload produced by `Usage#serialize`
+          # carries base's own `thinking_tokens` key and no `output_tokens_details`, so assigning unconditionally
+          # would clobber a correctly-parsed value with nil and break the round-trip. `unless nil?` rather than
+          # `||=`, so a reported zero from the wire still wins over base's nil.
+          reasoning_tokens = data.dig("output_tokens_details", "reasoning_tokens")
+          usage.thinking_tokens = reasoning_tokens unless reasoning_tokens.nil?
+
           usage
         end
       end

--- a/lib/omniai/openai/version.rb
+++ b/lib/omniai/openai/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module OpenAI
-    VERSION = "3.1.2"
+    VERSION = "3.2.0"
   end
 end

--- a/omniai-openai.gemspec
+++ b/omniai-openai.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 3.0"
+  spec.add_dependency "omniai", "~> 3.8"
   spec.add_dependency "openssl"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/openai/chat/usage_serializer_spec.rb
+++ b/spec/omniai/openai/chat/usage_serializer_spec.rb
@@ -78,5 +78,19 @@ RSpec.describe OmniAI::OpenAI::Chat::UsageSerializer do
         expect(deserialize.thinking_tokens).to be_nil
       end
     end
+
+    context "when round-tripping a base-serialized payload" do
+      # 'Usage#serialize' emits base's own 'thinking_tokens' key and no vendor container. Deserializing that back
+      # under this context must not clobber the parsed value with nil.
+      let(:data) do
+        OmniAI::Chat::Usage.new(input_tokens: 46, output_tokens: 1296, total_tokens: 1342, thinking_tokens: 444)
+          .serialize(context:)
+          .transform_keys(&:to_s)
+      end
+
+      it "preserves thinking_tokens" do
+        expect(deserialize.thinking_tokens).to be(444)
+      end
+    end
   end
 end

--- a/spec/omniai/openai/chat/usage_serializer_spec.rb
+++ b/spec/omniai/openai/chat/usage_serializer_spec.rb
@@ -6,51 +6,45 @@ RSpec.describe OmniAI::OpenAI::Chat::UsageSerializer do
   describe ".deserialize" do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 
-    # NOTE: these payloads are derived from the documented Responses API `usage` shape, not captured from a live
-    # response. No OpenAI credentials were available when this was written. Treat the key names as
-    # documentation-derived.
-
-    context "without a reasoning breakdown" do
-      let(:data) { { "input_tokens" => 2, "output_tokens" => 3, "total_tokens" => 5 } }
-
-      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
-      it { expect(deserialize.input_tokens).to be(2) }
-      it { expect(deserialize.output_tokens).to be(3) }
-      it { expect(deserialize.total_tokens).to be(5) }
-
-      it "leaves thinking_tokens nil rather than reporting zero" do
-        expect(deserialize.thinking_tokens).to be_nil
-      end
-    end
-
     context "with a reasoning breakdown" do
+      # Captured: gpt-5.6-luna, POST /v1/responses, thinking effort "high", 2026-08-20.
       let(:data) do
         {
-          "input_tokens" => 2,
-          "output_tokens" => 9,
-          "total_tokens" => 11,
-          "output_tokens_details" => { "reasoning_tokens" => 6 },
+          "input_tokens" => 46,
+          "input_tokens_details" => { "cache_write_tokens" => 0, "cached_tokens" => 0 },
+          "output_tokens" => 1296,
+          "output_tokens_details" => { "reasoning_tokens" => 444 },
+          "total_tokens" => 1342,
         }
       end
 
-      it { expect(deserialize.thinking_tokens).to be(6) }
+      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
+      it { expect(deserialize.input_tokens).to be(46) }
+      it { expect(deserialize.thinking_tokens).to be(444) }
+      it { expect(deserialize.total_tokens).to be(1342) }
 
       it "leaves output_tokens as reported, because OpenAI already counts reasoning in it" do
-        expect(deserialize.output_tokens).to be(9)
+        expect(deserialize.output_tokens).to be(1296)
       end
 
       it "keeps thinking_tokens a subset of output_tokens" do
         expect(deserialize.thinking_tokens).to be <= deserialize.output_tokens
       end
+
+      it "satisfies input + output == total on the captured response" do
+        expect(deserialize.input_tokens + deserialize.output_tokens).to eq(deserialize.total_tokens)
+      end
     end
 
     context "with a reasoning breakdown reporting zero" do
+      # The captured shape above with the reported value changed to zero — the value is constructed, the shape is
+      # captured. Pins that a wire-reported zero is preserved rather than collapsed to nil.
       let(:data) do
         {
-          "input_tokens" => 2,
-          "output_tokens" => 3,
-          "total_tokens" => 5,
+          "input_tokens" => 46,
+          "output_tokens" => 1296,
           "output_tokens_details" => { "reasoning_tokens" => 0 },
+          "total_tokens" => 1342,
         }
       end
 
@@ -59,14 +53,24 @@ RSpec.describe OmniAI::OpenAI::Chat::UsageSerializer do
       end
     end
 
+    context "without a reasoning breakdown" do
+      let(:data) { { "input_tokens" => 2, "output_tokens" => 3, "total_tokens" => 5 } }
+
+      it "leaves thinking_tokens nil rather than reporting zero" do
+        expect(deserialize.thinking_tokens).to be_nil
+      end
+    end
+
     context "with Chat Completions vocabulary from the previous API generation" do
-      # This gem targets `/responses`, which does not send `completion_tokens_details`. Asserting the miss keeps a
-      # future reader from re-adding a path for a shape this gem never receives.
+      # Captured evidence: the /v1/responses usage object reported input_tokens, input_tokens_details,
+      # output_tokens, output_tokens_details and total_tokens on 2026-08-20 — `completion_tokens_details` was
+      # absent entirely. Asserting the miss keeps a future reader from re-adding a path for a shape this gem
+      # never receives.
       let(:data) do
         {
-          "input_tokens" => 2,
-          "output_tokens" => 9,
-          "completion_tokens_details" => { "reasoning_tokens" => 6 },
+          "input_tokens" => 46,
+          "output_tokens" => 1296,
+          "completion_tokens_details" => { "reasoning_tokens" => 444 },
         }
       end
 

--- a/spec/omniai/openai/chat/usage_serializer_spec.rb
+++ b/spec/omniai/openai/chat/usage_serializer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::OpenAI::Chat::UsageSerializer do
+  let(:context) { OmniAI::OpenAI::Chat::CONTEXT }
+
+  describe ".deserialize" do
+    subject(:deserialize) { described_class.deserialize(data, context:) }
+
+    # NOTE: these payloads are derived from the documented Responses API `usage` shape, not captured from a live
+    # response. No OpenAI credentials were available when this was written. Treat the key names as
+    # documentation-derived.
+
+    context "without a reasoning breakdown" do
+      let(:data) { { "input_tokens" => 2, "output_tokens" => 3, "total_tokens" => 5 } }
+
+      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
+      it { expect(deserialize.input_tokens).to be(2) }
+      it { expect(deserialize.output_tokens).to be(3) }
+      it { expect(deserialize.total_tokens).to be(5) }
+
+      it "leaves thinking_tokens nil rather than reporting zero" do
+        expect(deserialize.thinking_tokens).to be_nil
+      end
+    end
+
+    context "with a reasoning breakdown" do
+      let(:data) do
+        {
+          "input_tokens" => 2,
+          "output_tokens" => 9,
+          "total_tokens" => 11,
+          "output_tokens_details" => { "reasoning_tokens" => 6 },
+        }
+      end
+
+      it { expect(deserialize.thinking_tokens).to be(6) }
+
+      it "leaves output_tokens as reported, because OpenAI already counts reasoning in it" do
+        expect(deserialize.output_tokens).to be(9)
+      end
+
+      it "keeps thinking_tokens a subset of output_tokens" do
+        expect(deserialize.thinking_tokens).to be <= deserialize.output_tokens
+      end
+    end
+
+    context "with a reasoning breakdown reporting zero" do
+      let(:data) do
+        {
+          "input_tokens" => 2,
+          "output_tokens" => 3,
+          "total_tokens" => 5,
+          "output_tokens_details" => { "reasoning_tokens" => 0 },
+        }
+      end
+
+      it "keeps a wire-reported zero, rather than collapsing it to nil" do
+        expect(deserialize.thinking_tokens).to be(0)
+      end
+    end
+
+    context "with Chat Completions vocabulary from the previous API generation" do
+      # This gem targets `/responses`, which does not send `completion_tokens_details`. Asserting the miss keeps a
+      # future reader from re-adding a path for a shape this gem never receives.
+      let(:data) do
+        {
+          "input_tokens" => 2,
+          "output_tokens" => 9,
+          "completion_tokens_details" => { "reasoning_tokens" => 6 },
+        }
+      end
+
+      it "does not read it" do
+        expect(deserialize.thinking_tokens).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

Reasoning spend is unreadable through this gem today. No `:usage` deserializer is registered, so `Usage#thinking_tokens` is always `nil` and callers have to reach into `response.data`.

## The key matters, and the obvious one is wrong

This gem targets the **Responses API** — `chat.rb:195` builds `/responses`, and `ResponseSerializer` deserializes `data["output"]`, not `data["choices"]`. The Responses `usage` object nests the reasoning breakdown under `output_tokens_details.reasoning_tokens`.

An earlier version of this work read `completion_tokens_details.reasoning_tokens` **in the base gem**. That is Chat Completions vocabulary from the previous API generation. It is not what this gem receives, so it was dead code — and this suite had **zero** usage specs to catch it.

Both problems are fixed here: the vocabulary moves into the gem that owns it, aimed at the key that gem actually gets.

## What changed

- `chat/usage_serializer.rb` reads `output_tokens_details.reasoning_tokens` into `Usage#thinking_tokens`, registered as `:usage` on the context.
- OpenAI already counts reasoning inside `output_tokens`, so the breakdown is read and the output total is left exactly as reported. `thinking_tokens` is a **subset**, not an addition — adding the two double counts.
- Usage specs, which this suite did not have. One of them asserts that `completion_tokens_details` is **not** read, so nobody re-adds a path for a shape this gem never sees.

## ✅ Captured — the earlier verification gap is closed

An earlier revision of this PR warned that it replaced one unverified key with another. **That gap is now closed.** Captured against the live API on 2026-08-20, `gpt-5.6-luna`, `POST /v1/responses`, thinking effort `high`:

```json
{
  "input_tokens": 46,
  "input_tokens_details": { "cache_write_tokens": 0, "cached_tokens": 0 },
  "output_tokens": 1296,
  "output_tokens_details": { "reasoning_tokens": 444 },
  "total_tokens": 1342
}
```

- **`output_tokens_details.reasoning_tokens` is confirmed** — 444 reasoning tokens inside 1296 output tokens, so the subset invariant holds on real data.
- **`completion_tokens_details` was absent entirely.** The path deleted from the base gem could never have fired here. The spec asserting that key is *not* read now cites captured evidence rather than an argument.
- `total_tokens` **is** present (unlike Anthropic), and `input + output == total` on the captured response.

The fixture carries provenance: model, endpoint, date. The zero-value case is the captured shape with the value changed, and says so inline.

### A near-miss worth naming

Anthropic uses the **same container name** — `output_tokens_details` — with a **different inner key** (`thinking_tokens`, confirmed by capture in [omniai-anthropic#209](https://github.com/ksylvest/omniai-anthropic/pull/209)). A single shared reader in the base gem would look obviously correct and silently return `nil` for one provider. That near-identity is the strongest argument for keeping vendor vocabulary in vendor gems.


## Round-trip fix

`Usage#serialize` under this context emits base's own `thinking_tokens` key and no `output_tokens_details`. The serializer originally assigned the vendor breakdown unconditionally, so deserializing a base-serialized payload parsed the value correctly and then overwrote it with `nil`:

```
serialized:             {input_tokens: 46, output_tokens: 1296, total_tokens: 1342, thinking_tokens: 444}
round-tripped thinking: nil
```

Now assigns only when the container is present — `unless thinking.nil?`, deliberately not `||=`, so a wire-reported `0` still wins over base's `nil`. That distinction is load-bearing rather than pedantic: the Anthropic sibling PR carries a **captured** zero.

A round-trip spec is added. `omniai-google` never had this bug because it implements both serialize and deserialize and specs the round-trip explicitly; this gem inherited half that pattern, and the half it dropped was the tested half.

## Branch hygiene

This branch was briefly based on [#215](https://github.com/ksylvest/omniai-openai/pull/215) rather than `main`, which put five unrelated files in its diff. It has been rebased onto `main` — `30a380b` is no longer an ancestor, and #215 retains it on its own branch. **#217 now stands alone and does not depend on #215 merging first.**

Current diff: 5 commits, 7 files, all usage. The `chat.rb` change is a single line registering the `:usage` deserializer.

## Compatibility

Requires **omniai >= 3.8** (ksylvest/omniai#305) for `Usage#thinking_tokens`. The floor moves `~> 3.0` → `~> 3.8` — a wider jump than the sibling gems, because this gemspec had not been tightened in some time.

**omniai 3.8.0 must be published before this can pass CI.**

## Verification

78 examples, 0 failures (was 68). RuboCop clean.

Part of a four-gem release: [omniai#305](https://github.com/ksylvest/omniai/pull/305) · [omniai-google#87](https://github.com/ksylvest/omniai-google/pull/87) · [omniai-anthropic#209](https://github.com/ksylvest/omniai-anthropic/pull/209)

